### PR TITLE
Allow mouse-picking the EntityEditor target entity

### DIFF
--- a/src/KorpiEngine.Runtime/Core/API/InputManagement/Input.cs
+++ b/src/KorpiEngine.Runtime/Core/API/InputManagement/Input.cs
@@ -1,4 +1,5 @@
-﻿using OpenTK.Windowing.GraphicsLibraryFramework;
+﻿using KorpiEngine.Core.Rendering;
+using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace KorpiEngine.Core.API.InputManagement;
 
@@ -7,7 +8,7 @@ public static class Input
     internal static KeyboardState KeyboardState = null!;
     internal static MouseState MouseState = null!;
     
-    public static Vector2 MousePosition => new(MouseState.X, MouseState.Y);
+    public static Vector2 MousePosition => new(MouseState.X, Graphics.ViewportResolution.Y - MouseState.Y);
     public static Vector2 MouseDelta => new(MouseState.Delta.X, MouseState.Delta.Y);
     public static Vector2 ScrollDelta => new(MouseState.Scroll.X, MouseState.Scroll.Y);
     public static float MouseX => MouseState.X;

--- a/src/KorpiEngine.Runtime/Core/Application.cs
+++ b/src/KorpiEngine.Runtime/Core/Application.cs
@@ -5,6 +5,7 @@ using KorpiEngine.Core.Debugging.Profiling;
 using KorpiEngine.Core.Logging;
 using KorpiEngine.Core.SceneManagement;
 using KorpiEngine.Core.Threading.Pooling;
+using KorpiEngine.Core.UI;
 using KorpiEngine.Core.UI.DearImGui;
 using KorpiEngine.Core.Windowing;
 using OpenTK.Windowing.Common;
@@ -21,9 +22,6 @@ public static class Application
     private static double fixedFrameAccumulator;
     private static KorpiWindow window = null!;
     private static Scene initialScene = null!;
-#if DEBUG
-    private static DebugStatsWindow debugStatsWindow = null!;
-#endif
     
     public static readonly IKorpiLogger Logger = LogFactory.GetLogger(typeof(Application));
     
@@ -84,7 +82,7 @@ public static class Application
         SceneManager.LoadScene(initialScene, SceneLoadMode.Single);
         
 #if DEBUG
-        debugStatsWindow = new DebugStatsWindow();
+        EditorGUI.Initialize();
 #endif
     }
 
@@ -174,7 +172,7 @@ public static class Application
     private static void OnUnload()
     {
 #if DEBUG
-        debugStatsWindow.Destroy();
+        EditorGUI.Deinitialize();
 #endif
         
         OnApplicationUnloadAttribute.Invoke();

--- a/src/KorpiEngine.Runtime/Core/Defaults/GBufferDebug.kshader
+++ b/src/KorpiEngine.Runtime/Core/Defaults/GBufferDebug.kshader
@@ -106,7 +106,9 @@ Pass 0
 
 			
 #ifdef OBJECTID
-			color = vec4(texture(_GObjectID, TexCoords).r, 0.0, 0.0, 1.0);
+            float objectID = texture(_GObjectID, TexCoords).r;
+            float hue = fract(objectID * 0.618033988749895); // Golden ratio conjugate for better distribution
+            color = vec4(0.5 + 0.5 * cos(6.28318 * (hue + vec3(0.0, 0.333, 0.667))), 1.0);
 #endif
 
 			

--- a/src/KorpiEngine.Runtime/Core/EntityModel/IDs/ResourceID.cs
+++ b/src/KorpiEngine.Runtime/Core/EntityModel/IDs/ResourceID.cs
@@ -4,7 +4,11 @@ namespace KorpiEngine.Core.EntityModel.IDs;
 
 public static class ResourceID
 {
-    private static int nextID;
+    /// <summary>
+    /// The next ID to be assigned to a resource.
+    /// Starts at 1, because the ObjectID buffer (in G-Buffer) uses 0 as a "null" value.
+    /// </summary>
+    private static int nextID = 1;
     
     
     public static int Generate()

--- a/src/KorpiEngine.Runtime/Core/Rendering/Cameras/Camera.cs
+++ b/src/KorpiEngine.Runtime/Core/Rendering/Cameras/Camera.cs
@@ -24,7 +24,16 @@ public sealed class Camera : EntityComponent
 {
     private const int RENDER_TEXTURE_MAX_UNUSED_FRAMES = 10;
     
+    /// <summary>
+    /// The camera that is currently rendering.
+    /// </summary>
     internal static Camera RenderingCamera { get; private set; } = null!;
+    
+    /// <summary>
+    /// The camera that last rendered a frame.
+    /// May change during rendering.
+    /// </summary>
+    internal static Camera? LastRenderedCamera { get; private set; }
     
     public event Action<int, int>? Resized;
 
@@ -110,6 +119,7 @@ public sealed class Camera : EntityComponent
         
         // Use the current view and projection matrices
         RenderingCamera = this;
+        LastRenderedCamera = this;
         
         Graphics.ViewMatrix = ViewMatrix;
         Graphics.OldViewMatrix = _oldView ?? Graphics.ViewMatrix;

--- a/src/KorpiEngine.Runtime/Core/Rendering/GBuffer.cs
+++ b/src/KorpiEngine.Runtime/Core/Rendering/GBuffer.cs
@@ -69,7 +69,7 @@ public class GBuffer
         Debug.Assert(FrameBuffer != null, nameof(FrameBuffer) + " != null");
         
         Graphics.Device.BindFramebuffer(FrameBuffer);
-        float result = Graphics.Device.ReadPixels<float>(5, x, y, TextureImageFormat.R_16_F);
+        float result = Graphics.Device.ReadPixels<float>(5, x, y, TextureImageFormat.R_32_F);
         return (int)result;
     }
 

--- a/src/KorpiEngine.Runtime/Core/Rendering/OpenGL/GLGraphicsDevice.cs
+++ b/src/KorpiEngine.Runtime/Core/Rendering/OpenGL/GLGraphicsDevice.cs
@@ -343,12 +343,8 @@ internal sealed unsafe class GLGraphicsDevice : GraphicsDevice
     {
         GL.ReadBuffer((ReadBufferMode)((int)ReadBufferMode.ColorAttachment0 + attachment));
         GLTexture.GetTextureFormatEnums(format, out PixelInternalFormat _, out PixelType pixelType, out PixelFormat pixelFormat);
-
         T result = default;
-        GCHandle handle = GCHandle.Alloc(result, GCHandleType.Pinned);
-        GL.ReadPixels(x, y, 1, 1, pixelFormat, pixelType, handle.AddrOfPinnedObject());
-        handle.Free();
-
+        GL.ReadPixels(x, y, 1, 1, pixelFormat, pixelType, ref result);
         return result;
     }
 

--- a/src/KorpiEngine.Runtime/Core/Resource.cs
+++ b/src/KorpiEngine.Runtime/Core/Resource.cs
@@ -94,7 +94,7 @@ public abstract class Resource : IDisposable
     public override string ToString() => Name;
 
 
-    /*public static T? FindObjectOfType<T>() where T : Resource
+    public static T? FindObjectOfType<T>() where T : Resource
     {
         foreach (WeakReference<Resource> obj in AllResources.Values)
             if (obj.TryGetTarget(out Resource? target) && target is T t)
@@ -105,7 +105,7 @@ public abstract class Resource : IDisposable
 
     public static T?[] FindObjectsOfType<T>() where T : Resource
     {
-        List<T> objects = new();
+        List<T> objects = [];
         foreach (WeakReference<Resource> obj in AllResources.Values)
             if (obj.TryGetTarget(out Resource? target) && target is T t)
                 objects.Add(t);
@@ -125,7 +125,7 @@ public abstract class Resource : IDisposable
     }
 
 
-    public static EngineObject Instantiate(EngineObject obj, bool keepAssetID = false)
+    /*public static EngineObject Instantiate(EngineObject obj, bool keepAssetID = false)
     {
         if (obj.IsDestroyed)
             throw new Exception(obj.Name + " has been destroyed.");

--- a/src/KorpiEngine.Runtime/Core/UI/DearImGui/EntityEditor.cs
+++ b/src/KorpiEngine.Runtime/Core/UI/DearImGui/EntityEditor.cs
@@ -31,12 +31,11 @@ public class EntityEditor() : ImGuiWindow(true)
             return;
         
         Entity? e = Resource.FindObjectByID<Entity>(instanceID);
-        if (e != null)
-            SetTarget(e);
+        SetTarget(e);
     }
 
 
-    public void SetTarget(Entity entity)
+    public void SetTarget(Entity? entity)
     {
         _target = new ResourceRef<Entity>(entity);
     }
@@ -59,6 +58,15 @@ public class EntityEditor() : ImGuiWindow(true)
 
     private static void DrawEntityHierarchy(Entity entity)
     {
+        // Inline destroy button
+        if (ImGui.Button("Destroy"))
+        {
+            entity.Destroy();
+            return;
+        }
+        ImGui.SameLine();
+        
+        // Transform hierarchy
         if (entity.HasChildren)
         {
             if (!ImGui.TreeNode(entity.Name))

--- a/src/KorpiEngine.Runtime/Core/UI/DearImGui/EntityEditor.cs
+++ b/src/KorpiEngine.Runtime/Core/UI/DearImGui/EntityEditor.cs
@@ -1,26 +1,59 @@
 ﻿using ImGuiNET;
+using KorpiEngine.Core.API;
+using KorpiEngine.Core.API.InputManagement;
 using KorpiEngine.Core.EntityModel;
+using KorpiEngine.Core.Internal.AssetManagement;
+using KorpiEngine.Core.Rendering;
+using KorpiEngine.Core.Rendering.Cameras;
 
 namespace KorpiEngine.Core.UI.DearImGui;
 
-public class EntityEditor : ImGuiWindow
+public class EntityEditor() : ImGuiWindow(true)
 {
-    private readonly Entity _target;
+    private ResourceRef<Entity> _target;
 
-    public override string Title => $"Entity Editor - {_target.Name}";
+    public override string Title => "Entity Editor";
 
-
-    public EntityEditor(Entity target) : base(false)
+    protected override void PreUpdate()
     {
-        _target = target;
+        if (!Input.GetMouseDown(MouseButton.Left))
+            return;
+
+        Vector2 mousePos = Input.MousePosition;
+        Vector2 mouseUV = new Vector2(mousePos.X / Graphics.ViewportResolution.X, mousePos.Y / Graphics.ViewportResolution.Y);
+        GBuffer? gBuffer = Camera.LastRenderedCamera?.GBuffer;
+        
+        if (gBuffer == null)
+            return;
+        
+        int instanceID = gBuffer.GetObjectIDAt(mouseUV);
+        if (instanceID == 0)
+            return;
+        
+        Entity? e = Resource.FindObjectByID<Entity>(instanceID);
+        if (e != null)
+            SetTarget(e);
+    }
+
+
+    public void SetTarget(Entity entity)
+    {
+        _target = new ResourceRef<Entity>(entity);
     }
 
 
     protected override void DrawContent()
     {
+        if (!_target.IsAvailable)
+        {
+            ImGui.Text("No entity selected.");
+            return;
+        }
+        
         ImGui.Text($"Entity: {_target.Name}");
         ImGui.Separator();
-        DrawEntityHierarchy(_target);
+        
+        DrawEntityHierarchy(_target.Res!);
     }
 
 

--- a/src/KorpiEngine.Runtime/Core/UI/DearImGui/EntityEditor.cs
+++ b/src/KorpiEngine.Runtime/Core/UI/DearImGui/EntityEditor.cs
@@ -16,7 +16,7 @@ public class EntityEditor() : ImGuiWindow(true)
 
     protected override void PreUpdate()
     {
-        if (!Input.GetMouseDown(MouseButton.Left))
+        if (!Input.GetMouseDown(MouseButton.Left) || GUI.WantCaptureMouse)
             return;
 
         Vector2 mousePos = Input.MousePosition;

--- a/src/KorpiEngine.Runtime/Core/UI/DearImGui/ImGuiController.cs
+++ b/src/KorpiEngine.Runtime/Core/UI/DearImGui/ImGuiController.cs
@@ -271,6 +271,9 @@ void main()
     private void UpdateImGuiInput(Vector2 mousePos)
     {
         ImGuiIOPtr io = ImGuiNET.ImGui.GetIO();
+        
+        GUI.WantCaptureKeyboard = io.WantCaptureKeyboard;
+        GUI.WantCaptureMouse = io.WantCaptureMouse;
 
         MouseState mouseState = Input.MouseState;
         KeyboardState keyboardState = Input.KeyboardState;

--- a/src/KorpiEngine.Runtime/Core/UI/EditorGUI.cs
+++ b/src/KorpiEngine.Runtime/Core/UI/EditorGUI.cs
@@ -5,21 +5,21 @@ namespace KorpiEngine.Core.UI;
 #if DEBUG
 public static class EditorGUI
 {
-    private static DebugStatsWindow debugStatsWindow = null!;
-    private static EntityEditor entityEditorWindow = null!;
+    public static DebugStatsWindow DebugStatsWindow { get; private set; } = null!;
+    public static EntityEditor EntityEditorWindow { get; private set; } = null!;
     
     
     public static void Initialize()
     {
-        debugStatsWindow = new DebugStatsWindow();
-        entityEditorWindow = new EntityEditor();
+        DebugStatsWindow = new DebugStatsWindow();
+        EntityEditorWindow = new EntityEditor();
     }
     
     
     public static void Deinitialize()
     {
-        debugStatsWindow.Destroy();
-        entityEditorWindow.Destroy();
+        DebugStatsWindow.Destroy();
+        EntityEditorWindow.Destroy();
     }
 }
 #endif

--- a/src/KorpiEngine.Runtime/Core/UI/EditorGUI.cs
+++ b/src/KorpiEngine.Runtime/Core/UI/EditorGUI.cs
@@ -1,0 +1,25 @@
+﻿using KorpiEngine.Core.UI.DearImGui;
+
+namespace KorpiEngine.Core.UI;
+
+#if DEBUG
+public static class EditorGUI
+{
+    private static DebugStatsWindow debugStatsWindow = null!;
+    private static EntityEditor entityEditorWindow = null!;
+    
+    
+    public static void Initialize()
+    {
+        debugStatsWindow = new DebugStatsWindow();
+        entityEditorWindow = new EntityEditor();
+    }
+    
+    
+    public static void Deinitialize()
+    {
+        debugStatsWindow.Destroy();
+        entityEditorWindow.Destroy();
+    }
+}
+#endif

--- a/src/KorpiEngine.Runtime/Core/UI/GUI.cs
+++ b/src/KorpiEngine.Runtime/Core/UI/GUI.cs
@@ -11,6 +11,9 @@ public static class GUI
     internal static bool AllowDraw { get; set; }
     internal static bool IsDrawing { get; private set; }
     
+    public static bool WantCaptureKeyboard { get; internal set; }
+    public static bool WantCaptureMouse { get; internal set; }
+    
     private static bool CanDraw => AllowDraw && IsDrawing;
     
     

--- a/src/KorpiEngine.Runtime/Sandbox/Program.cs
+++ b/src/KorpiEngine.Runtime/Sandbox/Program.cs
@@ -1,8 +1,6 @@
 ﻿using KorpiEngine.Core;
 using KorpiEngine.Core.API;
 using KorpiEngine.Core.Windowing;
-using Sandbox.Scenes;
-using Sandbox.Scenes.FullExample;
 using Sandbox.Scenes.SponzaExample;
 
 namespace Sandbox;

--- a/src/KorpiEngine.Runtime/Sandbox/Scenes/SponzaExample/SponzaLoader.cs
+++ b/src/KorpiEngine.Runtime/Sandbox/Scenes/SponzaExample/SponzaLoader.cs
@@ -2,7 +2,6 @@
 using KorpiEngine.Core.API.AssetManagement;
 using KorpiEngine.Core.EntityModel;
 using KorpiEngine.Core.Internal.AssetManagement.Importers;
-using KorpiEngine.Core.UI.DearImGui;
 using KorpiEngine.Networking;
 
 namespace Sandbox.Scenes.SponzaExample;

--- a/src/KorpiEngine.Runtime/Sandbox/Scenes/SponzaExample/SponzaLoader.cs
+++ b/src/KorpiEngine.Runtime/Sandbox/Scenes/SponzaExample/SponzaLoader.cs
@@ -95,6 +95,5 @@ internal class SponzaLoader : EntityComponent
         
         // Spawn the Sponza model in the scene
         asset.Spawn(Entity.Scene!);
-        ImGuiWindowManager.RegisterWindow(new EntityEditor(asset));
     }
 }

--- a/src/KorpiEngine.Runtime/Sandbox/Scripts/DemoFreeCam.cs
+++ b/src/KorpiEngine.Runtime/Sandbox/Scripts/DemoFreeCam.cs
@@ -61,7 +61,7 @@ internal class DemoFreeCam : EntityComponent
 
     private void UpdateCursorLock()
     {
-        if (Input.GetMouseDown(MouseButton.Right))
+        if (Input.GetMouseDown(MouseButton.Right) && !GUI.WantCaptureMouse)
             StartLooking();
         else if (Input.GetMouseUp(MouseButton.Right))
             StopLooking();


### PR DESCRIPTION
Also
[Fix GraphicsDevice.ReadPixelsInternal](https://github.com/japsuu/KorpiEngine/commit/f544b69d7ff5752d15f5abbc814da957ac19db64)
[Fix GBuffer.GetObjectIDAt](https://github.com/japsuu/KorpiEngine/commit/fde0c1504768d295a76ac4732824c05438c6505a)
[Fix inverted vertical Input.MousePosition](https://github.com/japsuu/KorpiEngine/commit/45fa483071827a8b0d1289d4f4308af5393ac681)
[Fix EntityEditor targeted entity switching through UI elements](https://github.com/japsuu/KorpiEngine/commit/8e6c39a6d09d2c8e15394a35ead5b15c7e9f45a9)
[Fix freecam input while hovering an UI element](https://github.com/japsuu/KorpiEngine/commit/d83e3724519e3f7da494fc3a6185b4d95f68a1c9)